### PR TITLE
Basic bitwise-generated texture mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,9 @@ clean_sim: clean sim
 
 clean_sim_random: clean sim_random
 
+csr: clean_sim_random
+
 # This tells make that 'test' and 'clean' are themselves not artefacts to make,
 # but rather tasks to always run:
-.PHONY: test clean sim sim_ones sim_random sim_seed show_results clean_sim clean_sim_random clean_build
+.PHONY: test clean sim sim_ones sim_random sim_seed show_results clean_sim clean_sim_random clean_build csr
 

--- a/sim/sim_main.cpp
+++ b/sim/sim_main.cpp
@@ -115,6 +115,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 {
   // char* nothing = "nothing";
   // return main(1, &nothing);
+  SetProcessDPIAware(); // Prevent window scaling, so we get a pixel-perfect SDL display.
   printf("DEBUG: WinMain command-line: '%s'\n", lpCmdLine);
   return main(__argc, __argv); // See: https://stackoverflow.com/a/40107581
   return 0;
@@ -287,9 +288,8 @@ void process_sdl_events() {
             //SMELL: Not implemented. Used to load a known set of vectors.
             break;
           }
-        case SDLK_q:
+        // case SDLK_q:
         case SDLK_ESCAPE:
-          // ESC or Q key pressed, for Quit
           gQuit = true;
           break;
         case SDLK_SPACE:

--- a/sim/sim_main.cpp
+++ b/sim/sim_main.cpp
@@ -38,8 +38,8 @@ using namespace std;
 //#define USE_SPEAKER
 
 //SMELL: These must be set to the same numbers in fixed_point_params.v:
-#define Qm  12
-#define Qn  12
+#define Qm  10
+#define Qn  10
 
 // #define USE_POWER_PINS //NOTE: This is automatically set in the Makefile, now.
 #define INSPECT_INTERNAL //NOTE: This is automatically set in the Makefile, now.
@@ -774,12 +774,12 @@ void update_spi_state() {
         bits.clear();
         for (int i=0; i<74; ++i) {
           switch (i) {
-            case 0:   v = double2fixed(gView.px           ); p = 17; break;
-            case 15:  v = double2fixed(gView.py           ); p = 17; break;
-            case 30:  v = double2fixed(gView.fx * gView.sf); p = 13; break;
-            case 41:  v = double2fixed(gView.fy * gView.sf); p = 13; break;
-            case 52:  v = double2fixed(gView.vx * gView.sv); p = 13; break;
-            case 63:  v = double2fixed(gView.vy * gView.sv); p = 13; break;
+            case 0:   v = double2fixed(gView.px           ); p = Qn+5; break;
+            case 15:  v = double2fixed(gView.py           ); p = Qn+5; break;
+            case 30:  v = double2fixed(gView.fx * gView.sf); p = Qn+1; break;
+            case 41:  v = double2fixed(gView.fy * gView.sf); p = Qn+1; break;
+            case 52:  v = double2fixed(gView.vx * gView.sv); p = Qn+1; break;
+            case 63:  v = double2fixed(gView.vy * gView.sv); p = Qn+1; break;
           }
           bits.push_back(v & (1<<p));
           --p;

--- a/src/rtl/map_rom.v
+++ b/src/rtl/map_rom.v
@@ -2,23 +2,23 @@
 `timescale 1ns / 1ps
 
 module map_rom #(
-  parameter MAP_WIDTH_BITS = 4,
-  parameter MAP_HEIGHT_BITS = 4
+  parameter MAP_WBITS   = 4,
+  parameter MAP_HBITS   = 4
 ) (
-  input [MAP_WIDTH_BITS-1:0]  i_col,
-  input [MAP_HEIGHT_BITS-1:0] i_row,
-  output                      o_val
+  input [MAP_WBITS-1:0] i_col,
+  input [MAP_HBITS-1:0] i_row,
+  output                o_val
 );
 
-  localparam COL_COUNT = (1<<MAP_WIDTH_BITS);
-  localparam ROW_COUNT = (1<<MAP_HEIGHT_BITS);
+  localparam COL_COUNT = (1<<MAP_WBITS);
+  localparam ROW_COUNT = (1<<MAP_HBITS);
   localparam MAX_COL = COL_COUNT-1;
   localparam MAX_ROW = ROW_COUNT-1;
 
   assign o_val =
     i_col == 0 || i_col == MAX_COL || // Left and right borders.
     i_row == 0 || i_row == MAX_ROW || // Top and bottom borders.
-      ((~i_row[2:0]==i_col[2:0]) & ~i_row[3] & ~i_col[3]) ||
+      ((~i_row[2:0]==i_col[2:0]) & ~i_row[3] & ~i_col[3]) || // Diagonal in top-left corner of map.
       (((
         (i_row[1] ^ i_col[2]) ^ (i_row[0] & i_col[1])
       ) & i_row[2] & i_col[1]) | (~i_row[0]&~i_col[0]))

--- a/src/rtl/rbzero.v
+++ b/src/rtl/rbzero.v
@@ -53,7 +53,8 @@ module rbzero(
   wire        wall_en;              // Asserted for the duration of the textured wall being visible on screen.
   wire [5:0]  wall_rgb;             // Colour of the current wall pixel being scanned.
   reg `F      texV;                 // Note big 'V': Fixed-point accumulator for working out texv per pixel. //SMELL: Wasted excess precision.
-  wire [5:0]  texv = texV[8:3];     // At vdist of 1.0, a 64p texture is stretched to 512p, hence texv is 64/512 (>>3) of int(texV).
+  wire `F     texVV = texV + traced_texVinit;
+  wire [5:0]  texv = texVV[8:3];     // At vdist of 1.0, a 64p texture is stretched to 512p, hence texv is 64/512 (>>3) of int(texV).
   //NOTE: Would it be possible to do primitive texture 'filtering' using 50/50 checker dither for texxture sub-pixels?
   row_render row_render(
     // Inputs:
@@ -66,18 +67,11 @@ module rbzero(
     .rgb      (wall_rgb),
     .hit      (wall_en)
   );
-  //NOTE: The wall is 512 pixels tall at a vdist of 1 'unit'
-  // (which in [6:-9] is 16'b0000001.000000000).
-  // Thus, each texel scales up by 512/64 = 8, or the inverse: its lookup scales down by 8.
+  // texV scans the texture 'v' coordinate range with a step size of 'traced_texa'.
+  //NOTE: Because of 'texVV = texV + traced_texVinit' above, texV might be relative to
+  // a positive, 0, or negative starting point as calculated by wall_tracer.
   //SMELL: Move this into some other module, e.g. row_render?
-  always @(posedge clk) begin
-    if (reset || hmax) begin //SMELL: Use hmax instead of hsync?? Or just use !wall_en?
-      texV <= traced_texVinit; //SMELL: Init this to actual wall scan starting point (in case the wall is bigger than the screen).
-    end else if (wall_en) begin
-      // While wall pixels are being painted, keep incrementing our texv accumulator.
-      texV <= texV + traced_texa;
-    end
-  end
+  always @(posedge clk) texV <= hmax ? 0 : texV + traced_texa;
 
   // --- Point-Of-View data, i.e. view vectors: ---
   wire `F playerX /* verilator public */;

--- a/src/rtl/rbzero.v
+++ b/src/rtl/rbzero.v
@@ -56,6 +56,7 @@ module rbzero(
     // Inputs:
     .side     (traced_side),
     .size     (traced_size),
+    .texu     (traced_texu),
     .hpos     (hpos),
     // Outputs:
     .rgb      (wall_rgb),
@@ -150,6 +151,7 @@ module rbzero(
   // --- Row-level ray caster/tracer: ---
   wire        traced_side;
   wire [10:0] traced_size;  // Calculated from traced_vdist, in this module.
+  wire [5:0]  traced_texu;  // Texture 'u' coordinate value.
   wall_tracer #(
     .MAP_WIDTH_BITS(MAP_WIDTH_BITS),
     .MAP_HEIGHT_BITS(MAP_HEIGHT_BITS)
@@ -177,7 +179,8 @@ module rbzero(
     .o_state  (trace_state), //DEBUG.
 `endif//TRACE_STATE_DEBUG
     .o_side   (traced_side),
-    .o_size   (traced_size)
+    .o_size   (traced_size),
+    .o_tex_u  (traced_texu)
   );
 
 `ifdef TRACE_STATE_DEBUG

--- a/src/rtl/rbzero.v
+++ b/src/rtl/rbzero.v
@@ -72,9 +72,6 @@ module rbzero(
   //SMELL: Move this into some other module, e.g. row_render?
   always @(posedge clk) begin
     if (reset || hmax) begin //SMELL: Use hmax instead of hsync?? Or just use !wall_en?
-      // if (vpos==1) begin
-      //   $display("traced_texVinit = %X", traced_texVinit);
-      // end
       texV <= traced_texVinit; //SMELL: Init this to actual wall scan starting point (in case the wall is bigger than the screen).
     end else if (wall_en) begin
       // While wall pixels are being painted, keep incrementing our texv accumulator.

--- a/src/rtl/rbzero.v
+++ b/src/rtl/rbzero.v
@@ -59,8 +59,8 @@ module rbzero(
     // Inputs:
     .side     (traced_side),
     .size     (traced_size),
-    .texu     (traced_texu),
-    .texv     (texv),
+    .texu     (traced_texu),        //SMELL: Need to clamp texu/v so they don't wrap due to fixed-point precision loss.
+    .texv     (texv),               //...for texv, we could simply extend to [6:0] and check bit 6.
     .hpos     (hpos),
     // Outputs:
     .rgb      (wall_rgb),

--- a/src/rtl/rbzero.v
+++ b/src/rtl/rbzero.v
@@ -71,7 +71,10 @@ module rbzero(
   // Thus, each texel scales up by 512/64 = 8, or the inverse: its lookup scales down by 8.
   //SMELL: Move this into some other module, e.g. row_render?
   always @(posedge clk) begin
-    if (reset || hsync) begin //SMELL: Use hmax instead of hsync?? Or just use !wall_en?
+    if (reset || hmax) begin //SMELL: Use hmax instead of hsync?? Or just use !wall_en?
+      // if (vpos==1) begin
+      //   $display("traced_texVinit = %X", traced_texVinit);
+      // end
       texV <= traced_texVinit; //SMELL: Init this to actual wall scan starting point (in case the wall is bigger than the screen).
     end else if (wall_en) begin
       // While wall pixels are being painted, keep incrementing our texv accumulator.

--- a/src/rtl/row_render.v
+++ b/src/rtl/row_render.v
@@ -6,7 +6,8 @@ module row_render #(
 ) (
   input wire side,
   input wire [10:0] size, // Supports 0..2047; remember this is mirrored, too.
-  input wire [9:0] hpos,  // Current horizontal trace position.
+  input wire  [9:0] hpos, // Current horizontal trace position.
+  input wire  [5:0] texu, // Texture 'u' coordinate, 0..63
   output wire [5:0] rgb,  //NOTE: BBGGRR bit order.
   output wire hit         // Are we in this row or not?    
 );
@@ -16,8 +17,10 @@ module row_render #(
     (size > HALF_SIZE) ||
     ((HALF_SIZE-size <= {1'b0,hpos}) && ({1'b0,hpos} <= HALF_SIZE+size));
   //SMELL: For now, just arbitrarily assign a colour based on side. Later, do textures.
-  assign rgb = side ?
-    6'b11_00_00 :
-    6'b10_00_00;
+  assign rgb =
+    texu == 0   ? 6'b11_10_00 :
+    texu == 63  ? 6'b01_00_00 :
+    side        ? 6'b11_00_00 :
+                  6'b10_00_00;
 
 endmodule

--- a/src/rtl/row_render.v
+++ b/src/rtl/row_render.v
@@ -8,6 +8,7 @@ module row_render #(
   input wire [10:0] size, // Supports 0..2047; remember this is mirrored, too.
   input wire  [9:0] hpos, // Current horizontal trace position.
   input wire  [5:0] texu, // Texture 'u' coordinate, 0..63
+  input wire  [5:0] texv, // Texture 'v' coordinate, 0..63
   output wire [5:0] rgb,  //NOTE: BBGGRR bit order.
   output wire hit         // Are we in this row or not?    
 );
@@ -17,10 +18,14 @@ module row_render #(
     (size > HALF_SIZE) ||
     ((HALF_SIZE-size <= {1'b0,hpos}) && ({1'b0,hpos} <= HALF_SIZE+size));
   //SMELL: For now, just arbitrarily assign a colour based on side. Later, do textures.
+  wire check = texu[0]^texv[0];
   assign rgb =
-    texu == 0   ? 6'b11_10_00 :
-    texu == 63  ? 6'b01_00_00 :
-    side        ? 6'b11_00_00 :
-                  6'b10_00_00;
+    side  ?   { 2'b11, check,1'b0, 2'b00 } :
+              { 2'b10, 1'b0,check, 2'b00 };
+    // { texu[2],1'b0, texu[1],1'b0, texu[0],1'b0 } >> side;
+    // texu == 0   ? 6'b11_10_00 :
+    // texu == 63  ? 6'b01_00_00 :
+    // side        ? 6'b11_00_00 :
+    //               6'b10_00_00;
 
 endmodule

--- a/src/rtl/row_render.v
+++ b/src/rtl/row_render.v
@@ -18,10 +18,12 @@ module row_render #(
     (size > HALF_SIZE) ||
     ((HALF_SIZE-size <= {1'b0,hpos}) && ({1'b0,hpos} <= HALF_SIZE+size));
   //SMELL: For now, just arbitrarily assign a colour based on side. Later, do textures.
-  wire check = texu[0]^texv[0];
-  assign rgb =
-    side  ?   { 2'b11, check,1'b0, 2'b00 } :
-              { 2'b10, 1'b0,check, 2'b00 };
+  assign rgb = {texu[0],side,texu[2],side,texu[4],side} ^ {texv[0],1'b0,texv[2],1'b0,texv[4],1'b0};
+  
+  // wire check = texu[0]^texv[0];
+  // assign rgb =
+  //   side  ?   { 2'b11, check,1'b0, 2'b00 } :
+  //             { 2'b10, 1'b0,check, 2'b00 };
     // { texu[2],1'b0, texu[1],1'b0, texu[0],1'b0 } >> side;
     // texu == 0   ? 6'b11_10_00 :
     // texu == 63  ? 6'b01_00_00 :

--- a/src/rtl/wall_tracer.v
+++ b/src/rtl/wall_tracer.v
@@ -44,8 +44,10 @@ module wall_tracer #(
 
   // Tracing result, per line:
   output reg                    o_side,
-  output reg [10:0]             o_size, // Wall half-size.
-  output reg [5:0]              o_tex_u // Texture 'u' coordinate (i.e. how far along the wall the hit was).
+  output reg [10:0]             o_size,   // Wall half-size.
+  output reg [5:0]              o_texu,   // Texture 'u' coordinate (i.e. how far along the wall the hit was).
+  output reg `F                 o_texa    // Addend for texv coord; actually visualWalLDist: equiv to o_size rcp, used for texture scaling.
+
 );
 
   //SMELL: Still need to define the function of 'tex'
@@ -264,6 +266,8 @@ module wall_tracer #(
         // keep it in case it needs to be reused?
         o_size <= 0;
         o_side <= 0;
+        o_texu <= 0;
+        o_texa <= 0;
         side <= 0;
         rcp_sel <= RCP_RDX; // Reciprocal's data source is initially rayDirX.
         visualWallDist <= 0;
@@ -336,7 +340,10 @@ module wall_tracer #(
             // Use the wall hit fractional value (6 bits of it) to determine the
             // wall texture offset in the range [0,63]...
             // By changing this we can change one axis of texture resolution or tiling.
-            o_tex_u <= wallPartial[-1:-6] ^ {6{texu_mirror}}; // Mirror when needed for correct texture orientation.
+            o_texu <= wallPartial[-1:-6] ^ {6{texu_mirror}}; // Mirror when needed for correct texture orientation.
+            o_texa <= visualWallDist;
+            //SMELL: o_tex_u probably doesn't need to be a reg on its port because wallPartial will
+            // soon be determined JIT by shmul...?
             // Increment rayAddend:
             rayAddendX <= rayAddendX + vplaneX;
             rayAddendY <= rayAddendY + vplaneY;


### PR DESCRIPTION
This introduces texture u/v coordinate calculation for 64x64 wall textures, and uses those UVs to generate a bitwise colour texture with shading based on `side`.